### PR TITLE
Compilers set by CC,cc are now only used if they are set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,16 @@ if(APPLE)
 else()
     message("Not running on Apple platform")
     # Configuration for non-Apple platforms
-    set(CMAKE_C_COMPILER cc)
-    set(CMAKE_CXX_COMPILER CC)
-    set(CMAKE_CUDA_HOST_COMPILER mpicxx)
+    if(cc)
+      set(CMAKE_C_COMPILER cc)
+    endif()
+    if(CC)
+      set(CMAKE_CXX_COMPILER CC)
+    endif()
+    if(mpicxx)
+      set(CMAKE_CUDA_HOST_COMPILER mpicxx)
+    endif()
 
-   
     # Set the nvshmem home directory
     list(APPEND CMAKE_PREFIX_PATH $ENV{HOME}/qasmtrans)
     # set(CMAKE_CUDA_FLAGS_RELEASE "-O3")


### PR DESCRIPTION
The build system did not work for me, as my Linux system does not have CC and cc set by default. I changed cmake to only use these if they are already set by the environment which now works on my system. If you prefer things to be done another way, just let me know and I'm happy to alter my pull request.