### PR TITLE
Throw errors when the circuit size is larger than the devices.

### DIFF
--- a/include/circuit_passes/transpiler.hpp
+++ b/include/circuit_passes/transpiler.hpp
@@ -27,6 +27,15 @@ using namespace std;
 void transpiler(shared_ptr<Circuit> circuit, shared_ptr<Chip> chip, map<string, creg> list_cregs, IdxType debug_level, IdxType mode)
 {
     circuit->set_creg(list_cregs);
+    IdxType n_qubits = IdxType(circuit->num_qubits());
+    IdxType chip_n_qubit = chip->chip_qubit_num;
+
+    if (n_qubits > chip_n_qubit)
+    {
+        std::cerr<<"Chip qubit number is smaller than the circuit."<<endl;
+        std::cerr<<"No transpilation has been performed."<<endl;
+        std::exit(1);
+    }
 
     //======================================== STEP-1: Initial Gate Decomposition =====================================
     cpu_timer initial_decompose_timer;

--- a/include/circuit_passes/transpiler.hpp
+++ b/include/circuit_passes/transpiler.hpp
@@ -32,8 +32,9 @@ void transpiler(shared_ptr<Circuit> circuit, shared_ptr<Chip> chip, map<string, 
 
     if (n_qubits > chip_n_qubit)
     {
-        std::cerr<<"Chip qubit number is smaller than the circuit."<<endl;
-        std::cerr<<"No transpilation has been performed."<<endl;
+        //std::cerr<<"Chip qubit number is smaller than the circuit."<<endl;
+        //std::cerr<<"No transpilation has been performed."<<endl;
+        throw std::logic_error{"Chip qubit number is smaller than the circuit. No transpilation has been performed."};
         std::exit(1);
     }
 


### PR DESCRIPTION
Add a judgment in the transpiler. When the circuit size is larger than the device qubit number, the transpiler will throw a logic_error before the transpilation process starts.